### PR TITLE
Add variable for enabling auto scale group metrics

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,7 +63,7 @@ module "ecs" {
   cluster_cpu_scale_out = 70
   # scale cluster in on cpu %
   cluster_cpu_scale_in = 20
-  # list of instance metrics we'd like to enable
+  # list of instance metrics we'd like to enable, defaults to empty array
   asg_metrics = ["GroupTerminatingInstances", "GroupMaxSize", "GroupDesiredCapacity", "GroupPendingInstances", "GroupInServiceInstances", "GroupMinSize", "GroupTotalInstances"]
 }
 

--- a/Readme.md
+++ b/Readme.md
@@ -63,6 +63,8 @@ module "ecs" {
   cluster_cpu_scale_out = 70
   # scale cluster in on cpu %
   cluster_cpu_scale_in = 20
+  # list of instance metrics we'd like to enable
+  asg_metrics = ["GroupTerminatingInstances", "GroupMaxSize", "GroupDesiredCapacity", "GroupPendingInstances", "GroupInServiceInstances", "GroupMinSize", "GroupTotalInstances"]
 }
 
 # This registers a "service" (a set of containers) in the cluster made above with the image tag specified. 

--- a/tf_ecs_cluster/asg.tf
+++ b/tf_ecs_cluster/asg.tf
@@ -42,6 +42,7 @@ resource "aws_autoscaling_group" "app" {
   launch_configuration = "${aws_launch_configuration.app.name}"
   termination_policies = ["OldestLaunchConfiguration", "OldestInstance"]
   depends_on           = ["aws_launch_configuration.app"]
+  enabled_metrics      = "${var.asg_metrics}"
 
   /*
        in 0.9.3 deletes are not handled properly when lc, and asg's have create before destroy

--- a/tf_ecs_cluster/variables.tf
+++ b/tf_ecs_cluster/variables.tf
@@ -67,5 +67,6 @@ variable "cluster_cpu_scale_in" {
 }
 
 variable "asg_metrics" {
+  description = "The list of metrics to enable for this auto scale group."
   default = []  
 }

--- a/tf_ecs_cluster/variables.tf
+++ b/tf_ecs_cluster/variables.tf
@@ -65,3 +65,7 @@ variable "cluster_cpu_scale_out" {
 variable "cluster_cpu_scale_in" {
   default = 20
 }
+
+variable "asg_metrics" {
+  default = []  
+}


### PR DESCRIPTION
Adding a "asg_metrics" variable, so that consumers of the ecs_cluster module can opt into instance metrics (free from fear that a future deployment will overwrite them).

Terraform Documentation: https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#enabled_metrics
