### PR TITLE
fix for deprecation warnings related to autoscaling policies

### DIFF
--- a/tf_ecs_default_service/ecs_task_scaling.tf
+++ b/tf_ecs_default_service/ecs_task_scaling.tf
@@ -13,13 +13,16 @@ resource "aws_appautoscaling_policy" "default-up" {
   service_namespace       = "ecs"
   resource_id             = "service/${var.cluster_name}/${aws_ecs_service.svc.name}"
   scalable_dimension      = "ecs:service:DesiredCount"
-  adjustment_type         = "ChangeInCapacity"
-  cooldown                = 60
-  metric_aggregation_type = "Average"
-
-  step_adjustment {
-    metric_interval_lower_bound = 0
-    scaling_adjustment          = 1
+  
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Average"
+  
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
   }
 
   depends_on = ["aws_appautoscaling_target.default"]
@@ -30,15 +33,17 @@ resource "aws_appautoscaling_policy" "default-down" {
   service_namespace       = "ecs"
   resource_id             = "service/${var.cluster_name}/${aws_ecs_service.svc.name}"
   scalable_dimension      = "ecs:service:DesiredCount"
-  adjustment_type         = "ChangeInCapacity"
-  cooldown                = 60
-  metric_aggregation_type = "Average"
 
-  step_adjustment {
-    metric_interval_lower_bound = 0
-    scaling_adjustment          = -1
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Average"
+  
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
   }
-
   depends_on = ["aws_appautoscaling_target.default"]
 }
 

--- a/tf_ecs_service/ecs_task_scaling.tf
+++ b/tf_ecs_service/ecs_task_scaling.tf
@@ -13,13 +13,16 @@ resource "aws_appautoscaling_policy" "default-up" {
   service_namespace       = "ecs"
   resource_id             = "service/${var.cluster_name}/${aws_ecs_service.svc.name}"
   scalable_dimension      = "ecs:service:DesiredCount"
-  adjustment_type         = "ChangeInCapacity"
-  cooldown                = 60
-  metric_aggregation_type = "Average"
-
-  step_adjustment {
-    metric_interval_lower_bound = 0
-    scaling_adjustment          = 1
+  
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Average"
+  
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
   }
 
   depends_on = ["aws_appautoscaling_target.default"]
@@ -30,13 +33,16 @@ resource "aws_appautoscaling_policy" "default-down" {
   service_namespace       = "ecs"
   resource_id             = "service/${var.cluster_name}/${aws_ecs_service.svc.name}"
   scalable_dimension      = "ecs:service:DesiredCount"
-  adjustment_type         = "ChangeInCapacity"
-  cooldown                = 60
-  metric_aggregation_type = "Average"
-
-  step_adjustment {
-    metric_interval_upper_bound = 0
-    scaling_adjustment          = -1
+  
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Average"
+  
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
   }
 
   depends_on = ["aws_appautoscaling_target.default"]


### PR DESCRIPTION
This is a fix for the deprecation warnings related to terraform's autoscaling changes.

Warnings:

  * module.node.aws_appautoscaling_policy.default-down: "adjustment_type": [DEPRECATED] Use step_scaling_policy_configuration -> adjustment_type instead
  * module.node.aws_appautoscaling_policy.default-down: "cooldown": [DEPRECATED] Use step_scaling_policy_configuration -> cooldown instead
  * module.node.aws_appautoscaling_policy.default-down: "metric_aggregation_type": [DEPRECATED] Use step_scaling_policy_configuration -> metric_aggregation_type instead
  * module.node.aws_appautoscaling_policy.default-down: "step_adjustment": [DEPRECATED] Use step_scaling_policy_configuration -> step_adjustment instead
  * module.node.aws_appautoscaling_policy.default-up: "adjustment_type": [DEPRECATED] Use step_scaling_policy_configuration -> adjustment_type instead
  * module.node.aws_appautoscaling_policy.default-up: "cooldown": [DEPRECATED] Use step_scaling_policy_configuration -> cooldown instead
  * module.node.aws_appautoscaling_policy.default-up: "metric_aggregation_type": [DEPRECATED] Use step_scaling_policy_configuration -> metric_aggregation_type instead
  * module.node.aws_appautoscaling_policy.default-up: "step_adjustment": [DEPRECATED] Use step_scaling_policy_configuration -> step_adjustment instead